### PR TITLE
MULE-13148: Add simple scheduler log functionality for diagnosing errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,10 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.quartz-scheduler</groupId>

--- a/src/main/java/org/mule/service/scheduler/internal/executor/ByCallerThreadGroupPolicy.java
+++ b/src/main/java/org/mule/service/scheduler/internal/executor/ByCallerThreadGroupPolicy.java
@@ -9,7 +9,8 @@ package org.mule.service.scheduler.internal.executor;
 import static java.lang.Thread.currentThread;
 import static java.util.Collections.unmodifiableSet;
 import static org.apache.commons.lang3.StringUtils.rightPad;
-import static org.slf4j.LoggerFactory.getLogger;
+import static org.mule.service.scheduler.internal.DefaultSchedulerService.USAGE_TRACE_INTERVAL_SECS;
+import static org.mule.service.scheduler.internal.DefaultSchedulerService.traceLogger;
 
 import org.mule.runtime.core.api.scheduler.SchedulerBusyException;
 import org.mule.service.scheduler.internal.threads.SchedulerThreadFactory;
@@ -19,8 +20,6 @@ import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor.AbortPolicy;
 import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
-
-import org.slf4j.Logger;
 
 /**
  * Dynamically determines the {@link RejectedExecutionHandler} implementation to use according to the {@link ThreadGroup} of the
@@ -33,8 +32,6 @@ import org.slf4j.Logger;
  * @since 1.0
  */
 public final class ByCallerThreadGroupPolicy implements RejectedExecutionHandler {
-
-  private static final Logger LOGGER = getLogger(ByCallerThreadGroupPolicy.class);
 
   private final AbortPolicy abort = new AbortPolicy() {
 
@@ -49,20 +46,16 @@ public final class ByCallerThreadGroupPolicy implements RejectedExecutionHandler
   private final Set<ThreadGroup> waitGroups;
   private final ThreadGroup parentGroup;
 
-  private final boolean logRejectionDetails;
-
   /**
    * Builds a new {@link ByCallerThreadGroupPolicy} with the given {@code waitGroups}.
    * 
    * @param waitGroups the group of threads for which a {@link WaitPolicy} will be applied. For the rest, an {@link AbortPolicy}
    *        will be applied.
    * @param parentGroup the {@link org.mule.runtime.core.api.scheduler.SchedulerService} parent {@link ThreadGroup}
-   * @param logRejectionDetails if {@code true}, every rejected task will be logged with WARN level.
    */
-  public ByCallerThreadGroupPolicy(Set<ThreadGroup> waitGroups, ThreadGroup parentGroup, boolean logRejectionDetails) {
+  public ByCallerThreadGroupPolicy(Set<ThreadGroup> waitGroups, ThreadGroup parentGroup) {
     this.waitGroups = unmodifiableSet(waitGroups);
     this.parentGroup = parentGroup;
-    this.logRejectionDetails = logRejectionDetails;
   }
 
   @Override
@@ -71,23 +64,23 @@ public final class ByCallerThreadGroupPolicy implements RejectedExecutionHandler
     ThreadGroup currentThreadGroup = currentThread().getThreadGroup();
 
     if (isWaitGroupThread(targetGroup) && targetGroup == currentThreadGroup) {
-      logRejection(r.toString(), "callerRuns", targetGroup.getName());
+      logRejection(r.toString(), callerRuns.getClass().getSimpleName(), targetGroup.getName());
       callerRuns.rejectedExecution(r, executor);
     } else if (!isSchedulerThread(currentThreadGroup) || isWaitGroupThread(currentThreadGroup)) {
-      logRejection(r.toString(), "wait", targetGroup.getName());
+      logRejection(r.toString(), wait.getClass().getSimpleName(), targetGroup.getName());
       // MULE-11460 Make CPU-intensive pool a ForkJoinPool - keep the parallelism when waiting.
       wait.rejectedExecution(r, executor);
     } else {
-      logRejection(r.toString(), "abort", targetGroup.getName());
+      logRejection(r.toString(), abort.getClass().getSimpleName(), targetGroup.getName());
       abort.rejectedExecution(r, executor);
     }
   }
 
   private void logRejection(String taskAsString, String strategy, String targetAsString) {
-    if (logRejectionDetails) {
-      LOGGER.warn("Task rejected ({}) from '{}' scheduler: {}", rightPad(strategy, 10), targetAsString, taskAsString);
-    } else if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("Task rejected ({}) from '{}' scheduler: {}", rightPad(strategy, 10), targetAsString, taskAsString);
+    if (USAGE_TRACE_INTERVAL_SECS != null) {
+      traceLogger.warn("Task rejected ({}) from '{}' scheduler: {}", rightPad(strategy, 16), targetAsString, taskAsString);
+    } else if (traceLogger.isDebugEnabled()) {
+      traceLogger.debug("Task rejected ({}) from '{}' scheduler: {}", rightPad(strategy, 16), targetAsString, taskAsString);
     }
   }
 

--- a/src/main/java/org/mule/service/scheduler/internal/executor/ByCallerThreadGroupPolicy.java
+++ b/src/main/java/org/mule/service/scheduler/internal/executor/ByCallerThreadGroupPolicy.java
@@ -8,6 +8,8 @@ package org.mule.service.scheduler.internal.executor;
 
 import static java.lang.Thread.currentThread;
 import static java.util.Collections.unmodifiableSet;
+import static org.apache.commons.lang3.StringUtils.rightPad;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import org.mule.runtime.core.api.scheduler.SchedulerBusyException;
 import org.mule.service.scheduler.internal.threads.SchedulerThreadFactory;
@@ -17,6 +19,8 @@ import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor.AbortPolicy;
 import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
+
+import org.slf4j.Logger;
 
 /**
  * Dynamically determines the {@link RejectedExecutionHandler} implementation to use according to the {@link ThreadGroup} of the
@@ -29,6 +33,8 @@ import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
  * @since 1.0
  */
 public final class ByCallerThreadGroupPolicy implements RejectedExecutionHandler {
+
+  private static final Logger LOGGER = getLogger(ByCallerThreadGroupPolicy.class);
 
   private final AbortPolicy abort = new AbortPolicy() {
 
@@ -43,16 +49,20 @@ public final class ByCallerThreadGroupPolicy implements RejectedExecutionHandler
   private final Set<ThreadGroup> waitGroups;
   private final ThreadGroup parentGroup;
 
+  private final boolean logRejectionDetails;
+
   /**
    * Builds a new {@link ByCallerThreadGroupPolicy} with the given {@code waitGroups}.
    * 
    * @param waitGroups the group of threads for which a {@link WaitPolicy} will be applied. For the rest, an {@link AbortPolicy}
    *        will be applied.
    * @param parentGroup the {@link org.mule.runtime.core.api.scheduler.SchedulerService} parent {@link ThreadGroup}
+   * @param logRejectionDetails if {@code true}, every rejected task will be logged with WARN level.
    */
-  public ByCallerThreadGroupPolicy(Set<ThreadGroup> waitGroups, ThreadGroup parentGroup) {
+  public ByCallerThreadGroupPolicy(Set<ThreadGroup> waitGroups, ThreadGroup parentGroup, boolean logRejectionDetails) {
     this.waitGroups = unmodifiableSet(waitGroups);
     this.parentGroup = parentGroup;
+    this.logRejectionDetails = logRejectionDetails;
   }
 
   @Override
@@ -61,12 +71,23 @@ public final class ByCallerThreadGroupPolicy implements RejectedExecutionHandler
     ThreadGroup currentThreadGroup = currentThread().getThreadGroup();
 
     if (isWaitGroupThread(targetGroup) && targetGroup == currentThreadGroup) {
+      logRejection(r.toString(), "callerRuns", targetGroup.getName());
       callerRuns.rejectedExecution(r, executor);
     } else if (!isSchedulerThread(currentThreadGroup) || isWaitGroupThread(currentThreadGroup)) {
+      logRejection(r.toString(), "wait", targetGroup.getName());
       // MULE-11460 Make CPU-intensive pool a ForkJoinPool - keep the parallelism when waiting.
       wait.rejectedExecution(r, executor);
     } else {
+      logRejection(r.toString(), "abort", targetGroup.getName());
       abort.rejectedExecution(r, executor);
+    }
+  }
+
+  private void logRejection(String taskAsString, String strategy, String targetAsString) {
+    if (logRejectionDetails) {
+      LOGGER.warn("Task rejected ({}) from '{}' scheduler: {}", rightPad(strategy, 10), targetAsString, taskAsString);
+    } else if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Task rejected ({}) from '{}' scheduler: {}", rightPad(strategy, 10), targetAsString, taskAsString);
     }
   }
 

--- a/src/main/java/org/mule/service/scheduler/internal/threads/SchedulerThreadPools.java
+++ b/src/main/java/org/mule/service/scheduler/internal/threads/SchedulerThreadPools.java
@@ -102,7 +102,7 @@ public class SchedulerThreadPools {
   private List<Scheduler> activeCpuIntensiveSchedulers = new ArrayList<>();
   private List<Scheduler> activeCustomSchedulers = new ArrayList<>();
 
-  public SchedulerThreadPools(String name, SchedulerPoolsConfig threadPoolsConfig, boolean logRejectionDetails) {
+  public SchedulerThreadPools(String name, SchedulerPoolsConfig threadPoolsConfig) {
     this.name = name;
     this.threadPoolsConfig = threadPoolsConfig;
 
@@ -114,8 +114,7 @@ public class SchedulerThreadPools {
     customGroup = new ThreadGroup(schedulerGroup, threadPoolsConfig.getThreadNamePrefix() + CUSTOM_THREADS_NAME);
     customWaitGroup = new ThreadGroup(customGroup, threadPoolsConfig.getThreadNamePrefix() + CUSTOM_THREADS_NAME);
 
-    byCallerThreadGroupPolicy =
-        new ByCallerThreadGroupPolicy(new HashSet<>(asList(ioGroup, customWaitGroup)), schedulerGroup, logRejectionDetails);
+    byCallerThreadGroupPolicy = new ByCallerThreadGroupPolicy(new HashSet<>(asList(ioGroup, customWaitGroup)), schedulerGroup);
   }
 
   public void start() throws MuleException {

--- a/src/main/java/org/mule/service/scheduler/internal/threads/SchedulerThreadPools.java
+++ b/src/main/java/org/mule/service/scheduler/internal/threads/SchedulerThreadPools.java
@@ -8,11 +8,11 @@ package org.mule.service.scheduler.internal.threads;
 
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.System.currentTimeMillis;
+import static java.lang.System.lineSeparator;
 import static java.util.Arrays.asList;
-import static java.util.Collections.synchronizedList;
-import static java.util.Collections.unmodifiableList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.commons.lang3.StringUtils.leftPad;
 import static org.mule.service.scheduler.ThreadType.CPU_INTENSIVE;
 import static org.mule.service.scheduler.ThreadType.CPU_LIGHT;
 import static org.mule.service.scheduler.ThreadType.CUSTOM;
@@ -30,6 +30,8 @@ import org.mule.service.scheduler.internal.DefaultScheduler;
 import org.mule.service.scheduler.internal.ThrottledScheduler;
 import org.mule.service.scheduler.internal.executor.ByCallerThreadGroupPolicy;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -44,6 +46,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -68,6 +73,7 @@ public class SchedulerThreadPools {
   private static final String TIMER_THREADS_NAME = "timer";
   private static final String CUSTOM_THREADS_NAME = CUSTOM.getName();
 
+  private String name;
   private SchedulerPoolsConfig threadPoolsConfig;
 
   private final ThreadGroup schedulerGroup;
@@ -87,9 +93,17 @@ public class SchedulerThreadPools {
   private ScheduledThreadPoolExecutor scheduledExecutor;
   private org.quartz.Scheduler quartzScheduler;
 
-  private List<Scheduler> activeSchedulers = synchronizedList(new ArrayList<>());
+  private ReadWriteLock activeSchedulersLock = new ReentrantReadWriteLock();
+  private Lock activeSchedulersReadLock = activeSchedulersLock.readLock();
+  private Lock activeSchedulersWriteLock = activeSchedulersLock.writeLock();
 
-  public SchedulerThreadPools(String name, SchedulerPoolsConfig threadPoolsConfig) {
+  private List<Scheduler> activeCpuLightSchedulers = new ArrayList<>();
+  private List<Scheduler> activeIoSchedulers = new ArrayList<>();
+  private List<Scheduler> activeCpuIntensiveSchedulers = new ArrayList<>();
+  private List<Scheduler> activeCustomSchedulers = new ArrayList<>();
+
+  public SchedulerThreadPools(String name, SchedulerPoolsConfig threadPoolsConfig, boolean logRejectionDetails) {
+    this.name = name;
     this.threadPoolsConfig = threadPoolsConfig;
 
     schedulerGroup = new ThreadGroup(name);
@@ -100,7 +114,8 @@ public class SchedulerThreadPools {
     customGroup = new ThreadGroup(schedulerGroup, threadPoolsConfig.getThreadNamePrefix() + CUSTOM_THREADS_NAME);
     customWaitGroup = new ThreadGroup(customGroup, threadPoolsConfig.getThreadNamePrefix() + CUSTOM_THREADS_NAME);
 
-    byCallerThreadGroupPolicy = new ByCallerThreadGroupPolicy(new HashSet<>(asList(ioGroup, customWaitGroup)), schedulerGroup);
+    byCallerThreadGroupPolicy =
+        new ByCallerThreadGroupPolicy(new HashSet<>(asList(ioGroup, customWaitGroup)), schedulerGroup, logRejectionDetails);
   }
 
   public void start() throws MuleException {
@@ -227,13 +242,14 @@ public class SchedulerThreadPools {
       scheduler =
           new ThrottledScheduler(schedulerName, cpuLightExecutor, parallelTasksEstimate, scheduledExecutor,
                                  quartzScheduler, CPU_LIGHT, config.getMaxConcurrentTasks(),
-                                 stopTimeout, shutdownCallback());
+                                 stopTimeout, shutdownCallback(activeCpuLightSchedulers));
     } else {
       scheduler = new DefaultScheduler(schedulerName, cpuLightExecutor, parallelTasksEstimate,
                                        scheduledExecutor, quartzScheduler, CPU_LIGHT,
-                                       stopTimeout, shutdownCallback());
+                                       stopTimeout, shutdownCallback(activeCpuLightSchedulers));
     }
-    activeSchedulers.add(scheduler);
+
+    addScheduler(activeCpuLightSchedulers, scheduler);
     return scheduler;
   }
 
@@ -245,18 +261,34 @@ public class SchedulerThreadPools {
       scheduler = new ThrottledScheduler(schedulerName, ioExecutor, workers,
                                          scheduledExecutor, quartzScheduler, IO,
                                          config.getMaxConcurrentTasks(), stopTimeout,
-                                         shutdownCallback());
+                                         shutdownCallback(activeIoSchedulers));
     } else {
       scheduler = new DefaultScheduler(schedulerName, ioExecutor, workers,
                                        scheduledExecutor, quartzScheduler, IO,
-                                       stopTimeout, shutdownCallback());
+                                       stopTimeout, shutdownCallback(activeIoSchedulers));
     }
-    activeSchedulers.add(scheduler);
+    addScheduler(activeIoSchedulers, scheduler);
     return scheduler;
   }
 
-  private Consumer<Scheduler> shutdownCallback() {
-    return schr -> activeSchedulers.remove(schr);
+  private boolean addScheduler(List<Scheduler> activeSchedulers, Scheduler scheduler) {
+    activeSchedulersWriteLock.lock();
+    try {
+      return activeSchedulers.add(scheduler);
+    } finally {
+      activeSchedulersWriteLock.unlock();
+    }
+  }
+
+  private Consumer<Scheduler> shutdownCallback(List<Scheduler> activeSchedulers) {
+    return schr -> {
+      activeSchedulersWriteLock.lock();
+      try {
+        activeSchedulers.remove(schr);
+      } finally {
+        activeSchedulersWriteLock.unlock();
+      }
+    };
   }
 
   public Scheduler createCpuIntensiveScheduler(SchedulerConfig config, int workers, Supplier<Long> stopTimeout) {
@@ -267,14 +299,14 @@ public class SchedulerThreadPools {
       scheduler = new ThrottledScheduler(schedulerName, computationExecutor, workers,
                                          scheduledExecutor, quartzScheduler,
                                          CPU_INTENSIVE, config.getMaxConcurrentTasks(), stopTimeout,
-                                         shutdownCallback());
+                                         shutdownCallback(activeCpuIntensiveSchedulers));
     } else {
       scheduler =
           new DefaultScheduler(schedulerName, computationExecutor, workers, scheduledExecutor,
                                quartzScheduler, CPU_INTENSIVE, stopTimeout,
-                               shutdownCallback());
+                               shutdownCallback(activeCpuIntensiveSchedulers));
     }
-    activeSchedulers.add(scheduler);
+    addScheduler(activeCpuIntensiveSchedulers, scheduler);
     return scheduler;
   }
 
@@ -307,18 +339,17 @@ public class SchedulerThreadPools {
       throw new IllegalArgumentException("Custom schedulers must define a thread pool size");
     }
 
-    final ThreadGroup customChildGroup = new ThreadGroup(resolveThreadGroupForCustomScheduler(config),
-                                                         threadPoolsConfig.getThreadNamePrefix() + "." + threadsName);
+    final ThreadGroup customChildGroup = new ThreadGroup(resolveThreadGroupForCustomScheduler(config), threadsName);
     final ThreadPoolExecutor executor =
         new ThreadPoolExecutor(config.getMaxConcurrentTasks(), config.getMaxConcurrentTasks(), 0L, MILLISECONDS, workQueue,
-                               new SchedulerThreadFactory(customChildGroup, "%s." + threadsName + ".%02d"),
+                               new SchedulerThreadFactory(customChildGroup, "%s.%02d"),
                                byCallerThreadGroupPolicy);
 
     final CustomScheduler customScheduler =
         new CustomScheduler(schedulerName, executor, workers, scheduledExecutor, quartzScheduler, CUSTOM, stopTimeout,
-                            shutdownCallback());
+                            shutdownCallback(activeCustomSchedulers));
     customSchedulersExecutors.add(executor);
-    activeSchedulers.add(customScheduler);
+    addScheduler(activeCustomSchedulers, customScheduler);
     return customScheduler;
   }
 
@@ -417,9 +448,69 @@ public class SchedulerThreadPools {
   }
 
   public List<Scheduler> getSchedulers() {
-    // TODO MULE-10549 Improve this syncronization
-    synchronized (activeSchedulers) {
-      return unmodifiableList(new ArrayList<>(activeSchedulers));
+    activeSchedulersReadLock.lock();
+    try {
+      return ImmutableList.<Scheduler>builder()
+          .addAll(activeCpuLightSchedulers)
+          .addAll(activeIoSchedulers)
+          .addAll(activeCpuIntensiveSchedulers)
+          .addAll(activeCustomSchedulers)
+          .build();
+    } finally {
+      activeSchedulersReadLock.unlock();
     }
+  }
+
+  public String buildReportString() {
+    final StringBuilder threadPoolsReportBuilder = new StringBuilder();
+
+    int schedulersCpuLight;
+    int schedulersIo;
+    int schedulersCpuIntensive;
+    int schedulersCustom;
+
+    activeSchedulersReadLock.lock();
+    try {
+      schedulersCpuLight = activeCpuLightSchedulers.size();
+      schedulersIo = activeIoSchedulers.size();
+      schedulersCpuIntensive = activeCpuIntensiveSchedulers.size();
+      schedulersCustom = activeCustomSchedulers.size();
+    } finally {
+      activeSchedulersReadLock.unlock();
+    }
+
+    final int cpuLightActiveCount = cpuLightExecutor.getActiveCount();
+    final int ioActiveCount = ioExecutor.getActiveCount();
+    final int cpuIntensiveActiveCount = computationExecutor.getActiveCount();
+
+    threadPoolsReportBuilder.append(lineSeparator() + name + lineSeparator());
+    threadPoolsReportBuilder.append("------------------------------------------------------------------------" + lineSeparator());
+    threadPoolsReportBuilder.append("Pool          | Schedulers | Idle threads | Used threads | Queued tasks " + lineSeparator());
+    threadPoolsReportBuilder.append("------------------------------------------------------------------------" + lineSeparator());
+    threadPoolsReportBuilder
+        .append("CPU Light     |"
+            + leftPad("" + schedulersCpuLight, 11) + " |"
+            + leftPad("" + (cpuLightExecutor.getPoolSize() - cpuLightActiveCount), 13) + " |"
+            + leftPad("" + cpuLightActiveCount, 13) + " |"
+            + leftPad("" + cpuLightExecutor.getQueue().size(), 13) + lineSeparator());
+    threadPoolsReportBuilder
+        .append("IO            |"
+            + leftPad("" + schedulersIo, 11) + " |"
+            + leftPad("" + (ioExecutor.getPoolSize() - ioActiveCount), 13) + " |"
+            + leftPad("" + ioActiveCount, 13) + " |"
+            + leftPad("" + ioExecutor.getQueue().size(), 13) + lineSeparator());
+    threadPoolsReportBuilder
+        .append("CPU Intensive |"
+            + leftPad("" + schedulersCpuIntensive, 11) + " |"
+            + leftPad("" + (computationExecutor.getPoolSize() - cpuIntensiveActiveCount), 13) + " |"
+            + leftPad("" + cpuIntensiveActiveCount, 13) + " |"
+            + leftPad("" + computationExecutor.getQueue().size(), 13) + lineSeparator());
+    threadPoolsReportBuilder
+        .append("Custom        |"
+            + leftPad("" + schedulersCustom, 11) + " |            - |            - |            -" + lineSeparator());
+    threadPoolsReportBuilder
+        .append("------------------------------------------------------------------------" + lineSeparator() + lineSeparator());
+
+    return threadPoolsReportBuilder.toString();
   }
 }

--- a/src/test/java/org/mule/service/scheduler/internal/SchedulerThreadPoolsTestCase.java
+++ b/src/test/java/org/mule/service/scheduler/internal/SchedulerThreadPoolsTestCase.java
@@ -67,7 +67,7 @@ public class SchedulerThreadPoolsTestCase extends AbstractMuleTestCase {
   @Before
   public void before() throws MuleException {
     threadPoolsConfig = loadThreadPoolsConfig();
-    service = new SchedulerThreadPools(SchedulerThreadPoolsTestCase.class.getName(), threadPoolsConfig);
+    service = new SchedulerThreadPools(SchedulerThreadPoolsTestCase.class.getName(), threadPoolsConfig, true);
     service.start();
   }
 

--- a/src/test/java/org/mule/service/scheduler/internal/SchedulerThreadPoolsTestCase.java
+++ b/src/test/java/org/mule/service/scheduler/internal/SchedulerThreadPoolsTestCase.java
@@ -67,7 +67,7 @@ public class SchedulerThreadPoolsTestCase extends AbstractMuleTestCase {
   @Before
   public void before() throws MuleException {
     threadPoolsConfig = loadThreadPoolsConfig();
-    service = new SchedulerThreadPools(SchedulerThreadPoolsTestCase.class.getName(), threadPoolsConfig, true);
+    service = new SchedulerThreadPools(SchedulerThreadPoolsTestCase.class.getName(), threadPoolsConfig);
     service.start();
   }
 


### PR DESCRIPTION
and better understanding performance tests.

Usage: 
	parameter when staring mule: `-M-Dmule.scheduler.usageTraceIntervalSecs=2`

Sample Outputs:

```
WARN  2017-07-21 15:52:50,364 [[MuleRuntime].cpuLight.15] org.mule.service.scheduler.internal.DefaultSchedulerService: ************************************************************************
WARN  2017-07-21 15:52:50,364 [[MuleRuntime].cpuLight.15] org.mule.service.scheduler.internal.DefaultSchedulerService: * Schedulers Usage Report                                              *
WARN  2017-07-21 15:52:50,364 [[MuleRuntime].cpuLight.15] org.mule.service.scheduler.internal.DefaultSchedulerService: ************************************************************************
WARN  2017-07-21 15:52:50,365 [[MuleRuntime].cpuLight.15] org.mule.service.scheduler.internal.DefaultSchedulerService: 
SchedulerService
------------------------------------------------------------------------
Pool          | Schedulers | Idle threads | Used threads | Queued tasks 
------------------------------------------------------------------------
CPU Light     |          2 |           15 |            1 |            0
IO            |          8 |            8 |            0 |            0
CPU Intensive |          0 |           16 |            0 |            0
Custom        |          3 |            - |            - |            -
------------------------------------------------------------------------


WARN  2017-07-21 15:52:50,365 [[MuleRuntime].cpuLight.15] org.mule.service.scheduler.internal.DefaultSchedulerService: ************************************************************************
```

```
WARN  2017-07-21 16:12:17,810 [[MuleRuntime].custom.01] org.mule.service.scheduler.internal.executor.ByCallerThreadGroupPolicy: Task rejected (abort     ) from ‘[MuleRuntime].custom’ scheduler: org.mule.service.scheduler.internal.SchedulerThreadPoolsTestCase$$Lambda$236/1818272224
```

Also, fix the issue that causes parts of the name of custom threads to be repeated.