### PR TITLE
MULE-11505: Explain why not implement cached IO scheduler that grows that uses async hand-off with queue

### DIFF
--- a/src/main/java/org/mule/service/scheduler/internal/RunnableRepeatableFutureDecorator.java
+++ b/src/main/java/org/mule/service/scheduler/internal/RunnableRepeatableFutureDecorator.java
@@ -70,7 +70,9 @@ class RunnableRepeatableFutureDecorator<V> extends AbstractRunnableFutureDecorat
       return;
     }
     if (cancelled) {
-      logger.debug("Task " + this.toString() + " has been cancelled. Retunrning immendiately.");
+      if (logger.isDebugEnabled()) {
+        logger.debug("Task " + this.toString() + " has been cancelled. Retunrning immendiately.");
+      }
       return;
     }
 

--- a/src/main/java/org/mule/service/scheduler/internal/executor/ByCallerThreadGroupPolicy.java
+++ b/src/main/java/org/mule/service/scheduler/internal/executor/ByCallerThreadGroupPolicy.java
@@ -42,7 +42,7 @@ public final class ByCallerThreadGroupPolicy extends AbstractByCallerPolicy impl
   }
 
   private final AbortPolicy abort = new AbortBusyPolicy();
-  private final WaitPolicy wait = new WaitPolicy();
+  private final WaitPolicy wait = new WaitPolicy(abort);
   private final CallerRunsPolicy callerRuns = new CallerRunsPolicy();
 
   private volatile long rejectedCount;


### PR DESCRIPTION
* Also, fix a flaky test caused by a deadlock in the quartz shutdown