### PR TITLE
MULE-14525: Scheduler unavailable error

### DIFF
--- a/src/main/java/org/mule/service/scheduler/internal/threads/SchedulerThreadPools.java
+++ b/src/main/java/org/mule/service/scheduler/internal/threads/SchedulerThreadPools.java
@@ -123,7 +123,8 @@ public class SchedulerThreadPools {
 
     byCallerThreadGroupPolicy = () -> new ByCallerThreadGroupPolicy(new HashSet<>(asList(ioGroup, customWaitGroup,
                                                                                          customCallerRunsAnsWaitGroup)),
-                                                                    new HashSet<>(asList(computationGroup, customCallerRunsGroup,
+                                                                    new HashSet<>(asList(cpuLightGroup, computationGroup,
+                                                                                         customCallerRunsGroup,
                                                                                          customCallerRunsAnsWaitGroup)),
                                                                     cpuLightGroup, schedulerGroup);
   }


### PR DESCRIPTION
Partial fix: allow caller-runs rejection strategy when doing cpuLite ->
cpuLite task dispatching