### PR TITLE
MULE-14590: ThrottlingScheduler active tasks count breaks when tasks are

### DIFF
--- a/src/main/java/org/mule/service/scheduler/internal/DefaultScheduler.java
+++ b/src/main/java/org/mule/service/scheduler/internal/DefaultScheduler.java
@@ -395,8 +395,8 @@ public class DefaultScheduler extends AbstractExecutorService implements Schedul
     scheduledTasks.put(task, scheduledFuture);
   }
 
-  protected void removeTask(RunnableFuture<?> task) {
-    scheduledTasks.remove(task);
+  protected ScheduledFuture<?> removeTask(RunnableFuture<?> task) {
+    return scheduledTasks.remove(task);
   }
 
   private void tryTerminate() {

--- a/src/main/java/org/mule/service/scheduler/internal/ThrottledScheduler.java
+++ b/src/main/java/org/mule/service/scheduler/internal/ThrottledScheduler.java
@@ -56,9 +56,12 @@ public class ThrottledScheduler extends DefaultScheduler {
   }
 
   @Override
-  protected void removeTask(RunnableFuture<?> task) {
-    super.removeTask(task);
-    thottlingPolicy.throttleWrapUp();
+  protected ScheduledFuture<?> removeTask(RunnableFuture<?> task) {
+    ScheduledFuture<?> removedTask = super.removeTask(task);
+    if (removedTask != null) {
+      thottlingPolicy.throttleWrapUp();
+    }
+    return removedTask;
   }
 
   @Override

--- a/src/test/java/org/mule/service/scheduler/internal/DefaultSchedulerScheduleTestCase.java
+++ b/src/test/java/org/mule/service/scheduler/internal/DefaultSchedulerScheduleTestCase.java
@@ -225,7 +225,7 @@ public class DefaultSchedulerScheduleTestCase extends AbstractMuleVsJavaExecutor
 
   @Test
   @Description("Tests that a delayed task is eventually triggered if at the original trigger time the target scheduler was busy")
-  public void scheduleWhilebusy() throws InterruptedException, ExecutionException, TimeoutException {
+  public void scheduleWhileBusy() throws InterruptedException, ExecutionException, TimeoutException {
     final CountDownLatch latch1 = new CountDownLatch(1);
     final CountDownLatch latch2 = new CountDownLatch(1);
 


### PR DESCRIPTION
cancelled.