### PR TITLE
MULE-14907: Avoid keeping references to muleContext from a CustomScheduler

### DIFF
--- a/src/main/java/org/mule/service/scheduler/internal/AbstractRunnableFutureDecorator.java
+++ b/src/main/java/org/mule/service/scheduler/internal/AbstractRunnableFutureDecorator.java
@@ -45,7 +45,7 @@ abstract class AbstractRunnableFutureDecorator<V> implements RunnableFuture<V> {
     try {
       threadLocalsField.set(currentThread(), null);
     } catch (Exception e) {
-      new MuleRuntimeException(e);
+      throw new MuleRuntimeException(e);
     }
   }
 

--- a/src/main/java/org/mule/service/scheduler/internal/executor/ByCallerThreadGroupPolicy.java
+++ b/src/main/java/org/mule/service/scheduler/internal/executor/ByCallerThreadGroupPolicy.java
@@ -51,7 +51,9 @@ public final class ByCallerThreadGroupPolicy extends AbstractByCallerPolicy impl
     public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
       String msg = "Task '" + r.toString() + "' rejected from Scheduler '" + schedulerName + "' ('"
           + executor.toString() + "')";
-      LOGGER.warn(msg);
+      if (!executor.isShutdown()) {
+        LOGGER.warn(msg);
+      }
       throw new SchedulerBusyException(msg);
     }
   }


### PR DESCRIPTION
Other changes:
* Fix wrongly handled exception
* Reduce verbosity of task rejection due to executor termination