### PR TITLE
MULE-16829: Setting low heap memory in multicore machine causes Mule to

### DIFF
--- a/src/main/java/org/mule/service/scheduler/internal/config/ContainerThreadPoolsConfig.java
+++ b/src/main/java/org/mule/service/scheduler/internal/config/ContainerThreadPoolsConfig.java
@@ -265,7 +265,7 @@ public class ContainerThreadPoolsConfig implements SchedulerPoolsConfig {
 
   @Override
   public OptionalInt getIoMaxPoolSize() {
-    return OptionalInt.of(ioMaxPoolSize);
+    return OptionalInt.of(max(ioCorePoolSize, ioMaxPoolSize));
   }
 
   private void setIoMaxPoolSize(int ioMaxPoolSize) {

--- a/src/test/java/org/mule/service/scheduler/internal/config/ThreadPoolsConfigTestCase.java
+++ b/src/test/java/org/mule/service/scheduler/internal/config/ThreadPoolsConfigTestCase.java
@@ -365,7 +365,7 @@ public class ThreadPoolsConfigTestCase extends AbstractMuleTestCase {
   @Description("Tests that the mule.schedulerPools.configFile property is honored if present")
   public void overrideConfigFile() throws IOException, MuleException {
     final Properties props = buildDefaultConfigProps();
-    props.put(IO_PREFIX + "." + THREAD_POOL_SIZE_MAX, "1");
+    props.put(IO_PREFIX + "." + THREAD_POOL_SIZE_MAX, "100");
 
     File overrideConfigFile = new File(tempOtherDir.getRoot(), "overriding.conf");
     props.store(new FileOutputStream(overrideConfigFile), "defaultConfig");
@@ -373,7 +373,7 @@ public class ThreadPoolsConfigTestCase extends AbstractMuleTestCase {
 
     final SchedulerPoolsConfig config = loadThreadPoolsConfig();
 
-    assertThat(config.getIoMaxPoolSize().getAsInt(), is(1));
+    assertThat(config.getIoMaxPoolSize().getAsInt(), is(100));
   }
 
 }


### PR DESCRIPTION
fail to start