### PR TITLE
MULE-16858: Race condition in prestartCoreThreads for a Scheduler

### DIFF
--- a/src/main/java/org/mule/service/scheduler/internal/threads/SchedulerThreadPools.java
+++ b/src/main/java/org/mule/service/scheduler/internal/threads/SchedulerThreadPools.java
@@ -394,7 +394,9 @@ public class SchedulerThreadPools {
   public Scheduler createCustomScheduler(SchedulerConfig config, int workers, Supplier<Long> stopTimeout) {
     String threadsName = resolveCustomThreadsName(config);
     return doCreateCustomScheduler(config, workers, stopTimeout, resolveCustomSchedulerName(config),
-                                   new SynchronousQueue<>(), threadsName);
+                                   // SynchronousQueue may reject tasks early right after creation/finish of the previous task
+                                   createQueue(config.getMaxConcurrentTasks()),
+                                   threadsName);
   }
 
   public Scheduler createCustomScheduler(SchedulerConfig config, int workers, Supplier<Long> stopTimeout, int queueSize) {

--- a/src/test/java/org/mule/service/scheduler/internal/SchedulerThreadPoolsTestCase.java
+++ b/src/test/java/org/mule/service/scheduler/internal/SchedulerThreadPoolsTestCase.java
@@ -138,6 +138,11 @@ public class SchedulerThreadPoolsTestCase extends AbstractMuleTestCase {
     final Scheduler custom =
         service.createCustomScheduler(config().withMaxConcurrentTasks(1), CORES, () -> 1000L);
 
+    // this will execute immediately
+    custom.execute(() -> {
+      awaitLatch(latch);
+    });
+    // this will be queued
     custom.execute(() -> {
       awaitLatch(latch);
     });


### PR DESCRIPTION
* Avoid use of SynchronousQueue for custom schedulers