### PR TITLE
MULE-17266: Remove the toString from the Executor in

### DIFF
--- a/src/main/java/org/mule/service/scheduler/internal/DefaultScheduler.java
+++ b/src/main/java/org/mule/service/scheduler/internal/DefaultScheduler.java
@@ -457,9 +457,14 @@ public class DefaultScheduler extends AbstractExecutorService implements Schedul
 
   @Override
   public String toString() {
-    return getThreadType() + " - " + getName() + "{" + lineSeparator()
-        + "  executor: " + executor.toString() + lineSeparator()
-        + "  shutdown: " + shutdown + lineSeparator()
-        + "}";
+    if (LOGGER.isDebugEnabled()) {
+      return getThreadType() + " - " + getName() + "{" + lineSeparator()
+          + "  executor: " + executor.toString() + lineSeparator()
+          + "  shutdown: " + shutdown + lineSeparator()
+          + "}";
+    } else {
+      return getThreadType() + " - " + getName() + "{shutdown: " + shutdown + "}";
+    }
+
   }
 }


### PR DESCRIPTION
DefaultScheduler#toString